### PR TITLE
Fix out of bounds error #9

### DIFF
--- a/src/vue-image-compare.vue
+++ b/src/vue-image-compare.vue
@@ -82,7 +82,8 @@ export default {
     onMouseMove(event, isDragging = this.isDragging) {
       if (isDragging && this.allowNextFrame) {
         this.allowNextFrame = false;
-        this.pageX = event.pageX || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX;
+        let x = event.pageX;
+        this.pageX = +(x !== 0) && (x || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX);
 
         window.requestAnimationFrame(this.updatePos);
       }


### PR DESCRIPTION
## Problem
In the original short-circuit expression
```
this.pageX = event.pageX || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX;
```

event.pageX could be number 0 which is a valid x location, but it was evaluated as false in the short-circuit and it would try to evaluate `event.targetTouches[0].pageX` which is undefined and caused an error.

## Fix
```js
this.pageX = +(x !== 0) && (x || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX)
```
### Case 1, x is 0
```js
+(x !== 0) = +(false) = 0 && (x || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX) = 0
this.pageX = 0
```

### Case 2, x is non-zero value, like 1
```js
+(x !== 0) = +(true) = 1 && (x || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX) = 1
this.pageX = 1
```

### Case 3, x is null
```js
+(x !== 0) = +(true) = 1 && (x || event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX) = event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX
this.pageX = event.targetTouches[0].pageX || event.originalEvent.targetTouches[0].pageX
```